### PR TITLE
Fix E2E, aiohttp_test_server.pytest used starllet by mistake

### DIFF
--- a/tests/aiohttp_test_server.py
+++ b/tests/aiohttp_test_server.py
@@ -2,17 +2,15 @@ import asyncio
 import logging
 import threading
 import time
-from asyncio.events import AbstractEventLoop
-from typing import Optional
 
+import requests
 from aiohttp import web
-from aiohttp.web_runner import AppRunner
-from starlette.responses import Response
 
 from pyctuator.pyctuator import Pyctuator
 from tests.conftest import PyctuatorServer
 
 
+# mypy: ignore_errors
 # pylint: disable=unused-variable
 class AiohttpPyctuatorServer(PyctuatorServer):
 
@@ -30,13 +28,13 @@ class AiohttpPyctuatorServer(PyctuatorServer):
         )
 
         @self.routes.get("/logfile_test_repeater")
-        def logfile_test_repeater(request: web.Request) -> web.Response:
+        async def logfile_test_repeater(request: web.Request) -> web.Response:
             repeated_string = request.query.get("repeated_string")
             logging.error(repeated_string)
             return web.Response(text=repeated_string)
 
         @self.routes.get("/httptrace_test_url")
-        def get_httptrace_test_url(request: web.Request) -> Response:
+        async def get_httptrace_test_url(request: web.Request) -> web.Response:
             # Sleep if requested to sleep - used for asserting httptraces timing
             sleep_sec = request.query.get("sleep_sec")
             if sleep_sec:
@@ -44,30 +42,39 @@ class AiohttpPyctuatorServer(PyctuatorServer):
                 time.sleep(int(sleep_sec))
 
             # Echo 'User-Data' header as 'resp-data' - used for asserting headers are captured properly
-            return Response(headers={"resp-data": str(request.headers.get("User-Data"))}, content="my content")
+            return web.Response(headers={"resp-data": str(request.headers.get("User-Data"))}, body="my content")
 
         self.app.add_routes(self.routes)
-        self.runner: Optional[AppRunner] = None
-        self.event_loop: Optional[AbstractEventLoop] = None
-        self.thread: Optional[threading.Thread] = None
 
-    async def _runner(self) -> None:
-        self.runner: AppRunner = web.AppRunner(self.app)
-        await self.runner.setup()
-        site = web.TCPSite(self.runner, "localhost", 8888)
+        self.thread = threading.Thread(target=self._start_in_thread)
+        self.should_stop_server = False
+        self.server_started = False
+
+    async def _run_server(self) -> None:
+        runner = web.AppRunner(self.app)
+        await runner.setup()
+
+        site = web.TCPSite(runner, "localhost", 8888)
         await site.start()
+        self.server_started = True
+
+        while not self.should_stop_server:
+            await asyncio.sleep(1)
+
+        await runner.shutdown()
+        await runner.cleanup()
+
+    def _start_in_thread(self) -> None:
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self._run_server())
+        loop.stop()
 
     def start(self) -> None:
-        self.event_loop = asyncio.new_event_loop()
-
-        self.event_loop.run_until_complete(self._runner())
-        self.thread = threading.Thread(target=lambda: self.event_loop.run_forever())
         self.thread.start()
+        while not self.server_started:
+            time.sleep(0.01)
 
     def stop(self) -> None:
         self.pyctuator.stop()
-        self.event_loop.stop()
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.runner.shutdown())
-        loop.run_until_complete(self.runner.cleanup())
+        self.should_stop_server = True
         self.thread.join()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Generator, Optional
+from typing import Generator, Optional, Dict
 
 import pytest
 import requests
@@ -66,12 +66,14 @@ def boot_admin_server(registration_tracker: RegistrationTrackerFixture) -> Gener
 
     # pylint: disable=unused-argument,unused-variable
     @boot_admin_app.post("/register", tags=["admin-server"])
-    def register(request: Request, registration: RegistrationRequest) -> None:
-        logging.debug("Got registration post %s - %s", registration, registration_tracker)
+    def register(request: Request, registration: RegistrationRequest) -> Dict[str, str]:
+        logging.debug("Got registration post %s, %d registrations since %s",
+                      registration, registration_tracker.count, registration_tracker.start_time)
         registration_tracker.registration = registration
         registration_tracker.count += 1
         if registration_tracker.start_time is None:
             registration_tracker.start_time = registration.metadata["startup"]
+        return {"id": "JB007"}
 
     # Start the mock boot-admin server that is needed to test pyctuator's registration
     boot_admin_config = Config(app=boot_admin_app, port=8001, loop="asyncio")

--- a/tests/test_pyctuator_e2e.py
+++ b/tests/test_pyctuator_e2e.py
@@ -21,9 +21,10 @@ from tests.fast_api_test_server import FastApiPyctuatorServer
 from tests.flask_test_server import FlaskPyctuatorServer
 
 
+# mypy: ignore_errors
 @pytest.fixture(
     params=[FastApiPyctuatorServer, FlaskPyctuatorServer, AiohttpPyctuatorServer],
-    ids=["FastAPI", "Flask", "aiohttp"],
+    ids=["FastAPI", "Flask", "aiohttp"]
 )
 def pyctuator_server(request) -> Generator:  # type: ignore
     # Start a the web-server in which the pyctuator is integrated


### PR DESCRIPTION
@amenezes, I've fixed the E2E.

Please review how I stop the aiohttp server in `tests/aiohttp_test_server.py' - i'm new to asyncio and to aiohttp.
Keep in mind that for the test, the aiohttp server needs to run in a separate thread.